### PR TITLE
Fixed bug where bar variable being used as index was not an integer.

### DIFF
--- a/show-volume.py
+++ b/show-volume.py
@@ -18,7 +18,7 @@ with open(home + "/.mute") as f:
 
 if isunmuted:
   volume = int(content[0])
-  bars = volume / 9000
+  bars = int(volume / 9000)
 
   if (volume % 9000 == 0):
     output = allbars[0:bars+1] + emptybars[bars+1:]


### PR DESCRIPTION
Hi,
This is the fix that I mentioned in Issue 1 where in my environment, bars was getting evaluated to a float rather that integer which was causing index errors.

Thanks,
Caleb
